### PR TITLE
PERF: support If-None-Match and ETag headers

### DIFF
--- a/doc/source/whatsnew/v0.1.3.rst
+++ b/doc/source/whatsnew/v0.1.3.rst
@@ -11,6 +11,7 @@ New features
 * Change default logging handler to RotatingFileHandler (or ConcurrentRotatingFileHandler under win32)
 * Add database operation record to keep track of number of calls and time spent
 * Seperate ``RequestChecker`` from ``ESI`` class, making check methods customizable
+* Add ``ESIRequestParser`` class
 
 Performance improvements
 ------------------------
@@ -18,6 +19,7 @@ Performance improvements
 * Buffer INSERT database call to reduce number of transactions
 * Buffer inspect.getsource to reduce make_cache_key speed overhead
 * Tracks cache entry ``expires`` and DELETE when time has passed
+* Support ``If-None-Match`` and ``Etag`` HTTP headers
 
 
 Contributors

--- a/eve_tools/ESI/esi.py
+++ b/eve_tools/ESI/esi.py
@@ -1,11 +1,11 @@
 import asyncio
 import aiohttp
-import copy
 from dataclasses import dataclass
 from tqdm.asyncio import tqdm_asyncio
 from typing import Iterable, Optional, Union, List, Tuple
 
 from .checker import ESIRequestChecker
+from .parser import ESIRequestParser
 from .token import ESITokens, Token
 from .metadata import ESIMetadata, ESIRequest
 from .application import ESIApplications, Application
@@ -64,11 +64,22 @@ class ESIResponse:
     def __len__(self):
         return len(self.data)
 
+    def __repr__(self) -> str:
+        return f"<Response [{self.status}]>"
+
     def raise_for_status(self):
         # Please note that this raise_for_status() is only intended for printing out useful exception message.
         # This method does not recreate aiohttp.ClientResponse's raise_for_status().
         if self.status >= 400:
             raise ESIResponseError(self.status, self.request_info, self.reason)
+
+    @property
+    def ok(self) -> bool:
+        """Returns ``True`` if ``status`` is ``200`` or ``304``, ``False`` if not.
+
+        This is **not** a check for ``200 OK``.
+        """
+        return self.status == 200 or self.status == 304
 
 
 class ESI(object):
@@ -80,13 +91,11 @@ class ESI(object):
         ESI class is singleton by design.
     """
 
-    metaurl = "https://esi.evetech.net/latest"
     default_callback = "https://localhost/callback/"
 
     def __init__(self):
 
         self.apps = ESIApplications()
-        self._metadata = ESIMetadata()
 
         ### Async request
         # Can't put this ClientSession instance to be a global variable.
@@ -109,6 +118,9 @@ class ESI(object):
         self.__request_checker = ESIRequestChecker()
         self.__singular_req = False  # Single/multiple async request(s)
         self.__raises = None  # user defined raise flag
+
+        ### Request parser
+        self.__parser = ESIRequestParser(self.apps)
 
         logger.info("ESI instance initiated")
 
@@ -141,7 +153,11 @@ class ESI(object):
     @property
     def checker(self) -> ESIRequestChecker:
         return self.__request_checker
-        
+
+    @property
+    def parser(self) -> ESIRequestParser:
+        return self.__parser
+
     @_session_recorder(fields="timer")
     def get(
         self,
@@ -186,9 +202,6 @@ class ESI(object):
                 EVE ESI does not require headers info, but supplying with User-Agent, etc., is recommended.
             kwd.cname: str
                 A string of character name. Token with cname would be used for the request.
-            kwd.generate_token: bool
-                A bool that specifies in case token doesn't exist, whether to go through token generation or raise errors.
-                Default generating tokens.
             kwd.checks: bool
                 Whether to use _RequestChecker to block incorrect requests, default True.
 
@@ -306,9 +319,6 @@ class ESI(object):
                 EVE ESI does not require headers info, but supplying with User-Agent, etc., is recommended.
             kwd.cname: str
                 A string of character name. Token with cname would be used for the request.
-            kwd.generate_token: bool
-                A bool that specifies in case token doesn't exist, whether to go through token generation or raise errors.
-                Default generating tokens
             kwd.checks: bool
                 Whether to use _RequestChecker to block incorrect requests, default True.
 
@@ -362,49 +372,28 @@ class ESI(object):
         See also:
             ESI.get(): sends asynchronous request GET to an API.
         """
-        self.__check_key(key)
-
-        api_request = self._metadata[key]
-        if api_request.request_type not in ["get", "head"]:
-            raise NotImplementedError(f"Request type {api_request.request_type} is not supported.")
-
-        api_request.kwd = copy.deepcopy(kwd)
-
-        self.__check_method(api_request, method)
-
-        params = kwd.get("params", {})
-        api_request.params.update(params)
-
-        headers = kwd.get("headers", {})
-        generate_token = kwd.get("generate_token", True)
-        # if has security and has no Authorization field, get auth token.
-        if api_request.security and not headers.get("Authorization"):
-            app = self.apps.search_scope(" ".join(api_request.security))
-            with ESITokens(app) as tokens:
-                cname = kwd.pop("cname", "any")
-                if generate_token and not tokens.exist(cname):
-                    logger.debug("Generating token for request: %s %s", method, key)
-                    token = tokens.generate()
-                else:
-                    token = tokens[cname]
-                api_request.token = token
-                headers.update(self.__get_auth_headers(token))
-
-        api_request.headers.update(headers)
 
         self.__raises = kwd.pop("raises", None)
         checks = kwd.pop("checks", True)
 
-        self.__parse_request_keywords(api_request, kwd)
+        api_request = await self.__parser(key, method, **kwd)
 
         # Using asyncio.run() is problematic because it creates a new event loop (or maybe other advanced/mysterious reasons?).
         # For my application (web request), aiohttp kind of like non-blocking accept in C,
         # where I need to use epoll (or select) to interrupt the blocking accept and do something else (like servering a client).
         # Something cool and slightly difficult to understand: https://stackoverflow.com/questions/49005651/how-does-asyncio-actually-work
         # self.async_request = ESIRequestError(raises=raises)(self.async_request)
-        res = await ESIRequestError(raises=self.__raises)(self.async_request)(
+        res: ESIResponse = await ESIRequestError(raises=self.__raises)(self.async_request)(
             api_request, method, checks=checks
         )
+
+        if res is not None:
+            etag = res.headers.get("Etag")
+            if res.status == 304:
+                # Uses etag cache
+                res.data = self.__parser._get_etag_payload(api_request.rid)
+            elif res.status == 200:
+                self.__parser._set_etag(api_request.rid, etag, res.data)
 
         self.__raises = None  # back to default
         return res
@@ -453,39 +442,41 @@ class ESI(object):
         if method == "get":
             async with self.__async_session.get(
                 api_request.url, params=api_request.params, headers=api_request.headers
-            ) as req:
-                api_request.url = str(req.url)  # URL class implements str
-                data = await req.json()
-                resp = ESIResponse(
-                    status=req.status,
-                    method=req.method,
-                    headers=dict(req.headers),
+            ) as resp:
+                api_request.url = str(resp.url)  # URL class implements str
+                data = None
+                if resp.status != 304:
+                    data = await resp.json()
+                ret = ESIResponse(
+                    status=resp.status,
+                    method=resp.method,
+                    headers=dict(resp.headers),
                     request_info=api_request,
                     data=data,
-                    expires=req.headers.get("Expires"),
-                    reason=req.reason,
-                    error_remain=int(req.headers.get("x-esi-error-limit-remain")),
-                    error_reset=int(req.headers.get("x-esi-error-limit-reset")),
+                    expires=resp.headers.get("Expires"),
+                    reason=resp.reason,
+                    error_remain=int(resp.headers.get("x-esi-error-limit-remain")),
+                    error_reset=int(resp.headers.get("x-esi-error-limit-reset")),
                 )
 
         elif method == "head":
             async with self.__async_session.head(
                 api_request.url, params=api_request.params, headers=api_request.headers
-            ) as req:
-                api_request.url = str(req.url)
-                resp = ESIResponse(
-                    status=req.status,
-                    method=req.method,
-                    headers=dict(req.headers),
+            ) as resp:
+                api_request.url = str(resp.url)
+                ret = ESIResponse(
+                    status=resp.status,
+                    method=resp.method,
+                    headers=dict(resp.headers),
                     request_info=api_request,
                     data=None,
-                    expires=req.headers.get("Expires"),
-                    reason=req.reason,
-                    error_remain=int(req.headers.get("x-esi-error-limit-remain")),
-                    error_reset=int(req.headers.get("x-esi-error-limit-reset")),
+                    expires=resp.headers.get("Expires"),
+                    reason=resp.reason,
+                    error_remain=int(resp.headers.get("x-esi-error-limit-remain")),
+                    error_reset=int(resp.headers.get("x-esi-error-limit-reset")),
                 )
 
-        return resp
+        return ret
 
     def add_app_generate_token(self, clientId: str, scope: str, callbackURL: Optional[str] = None) -> None:
         """Adds a new Application to the client and generate a token for it.
@@ -526,147 +517,6 @@ class ESI(object):
 
         with ESITokens(new_app) as token:
             token.generate()
-
-    def __get_auth_headers(self, token: Token) -> dict:
-        # Read from local token file and append to request headers.
-        access_token = token.access_token
-        auth_headers = {"Authorization": "Bearer {}".format(access_token)}
-        return auth_headers
-
-    def __check_key(self, key: str) -> None:
-        if key not in self._metadata.paths:
-            logger.error("Invalid request key: %s", key)
-            raise ValueError(f"{key} is not a valid request key.")
-
-    def __check_method(self, api_request: ESIRequest, method: str) -> None:
-        """Checks if method is supported by the ESIRequest.
-        Assume only one request_type (one of "get", "post", etc.) for api_request.
-        """
-        req_method = api_request.request_type
-        if req_method == method:
-            return
-
-        if method == "head" and req_method == "get":
-            return
-
-        logger.error("Invalid request method: %s", method)
-        raise ValueError(f"Request method {method} is not supported by {api_request.request_key} request.")
-
-    def __parse_request_keywords(self, api_request: ESIRequest, keywords: dict) -> None:
-        """Parses and checks user provided parameters.
-
-        Checks fields in keywords if necessary parameters are given.
-        Fills in ESIRequest with parameters parsed from keywords.
-
-        Args:
-            api_request: ESIRequest
-                A struct holding request info for an API request.
-                Necessary info (url, params, headers) is filled in according to metadata and some facts.
-            keywords: dict
-                Kwd argument provided by user, containing headers, params, and other necessary fields for the API.
-                Missing keywords (such as character_id) raises errors.
-
-        Facts:
-            _in: path
-                1. Param.required = True
-                2. Appears as {Param.name} in url: https://.../characters/{character_id}/orders/
-                3. Pass in with kwd argument, not params, headers, or data
-                4. Param.default is None
-            _in: query
-                1. Pass in with either kwd or params, not headers or data
-                2. Appears as ?query=value in url: https://.../?datasource=tranquility
-            _in: header
-                1. Request token has been updated to headers before calling this function
-                2. ESI marks "token" param as optional
-        """
-
-        path_params = {}  # params for request url.format()
-        query_params = {}  # params for url/?{key1}={value1}?{key2}={value2}...
-        headers = keywords.pop("headers", {})
-
-        cid = 0
-        if api_request.token is not None:
-            cid = api_request.token.character_id
-
-        for api_param_ in api_request.parameters:
-            if api_param_._in == "path":
-                key = api_param_.name
-                value = self.__parse_request_keywords_in_path(keywords, key, api_param_.dtype, cid)
-                path_params.update({key: value})
-                # dict unpacking later
-            elif api_param_._in == "query":
-                default = api_param_.default
-                key = api_param_.name
-                value = self.__parse_request_keywords_in_query(
-                    keywords,
-                    key,
-                    api_param_.required,
-                    api_param_.default,
-                    api_param_.dtype,
-                )
-                if value is not None:
-                    query_params.update({key: value})  # update if value is given
-                elif default is not None:
-                    query_params.update({key: default})  # else update if default is set
-            elif api_param_._in == "header":  # not "headers"
-                # usually not reached
-                key = api_param_.name
-                value = self.__parse_request_keywords_in_header(
-                    headers, key, api_param_.required, api_param_.dtype
-                )
-                if value is not None:
-                    headers.update({key: value})
-
-        url = api_request.request_key
-        url = url.format(**path_params)
-        api_request.params.update(query_params)
-        api_request.headers.update(headers)
-        api_request.url = self.metaurl + url  # urljoin is difficult to deal with...
-
-    @staticmethod
-    def __parse_request_keywords_in_path(where: dict, key: str, dtype: str, cid: int = 0) -> str:
-        # dtype is not checked yet. Checking it needs to parse "schema" field and integerate into "dtype",
-        # and needs to find a way to fit user input to the dtype field.
-        # No need to check Param.required because Param._in == "path" => Param.required == True
-        if key == "character_id" and cid > 0 and "character_id" not in where:
-            # Prioritizes user input character_id
-            return cid
-        value = where.pop(key, None)
-        if value is None:
-            raise KeyError(f'Missing key "{key}" in keywords.')
-        return value
-
-    @staticmethod
-    def __parse_request_keywords_in_query(
-        where: dict, key: str, required: bool, default, dtype: str
-    ) -> str:
-        value = where.pop(key, None)
-        params = where.get("params")
-        value2 = None
-        if params:
-            value2 = params.get(key)
-
-        if value and value2:
-            raise KeyError(f'Duplicate key "{key}" in both keywords and params.')
-
-        if value is None and value2 is None and required and default is None:
-            raise KeyError(f'Missing key "{key}" in keywords.')
-
-        if value is None and value2 is None:
-            return default
-        if value is not None:
-            return value
-        if value2 is not None:
-            return value2
-
-    @staticmethod
-    def __parse_request_keywords_in_header(where: dict, key: str, required: bool, dtype: str) -> str:
-        value = where.pop(key, None)
-        if not required:
-            return value
-        if value is None:
-            raise KeyError(f'Missing key "{key}" in keywords.')
-        return value
 
     def _start_record(self):
         """Starts recording useful response info."""

--- a/eve_tools/ESI/metadata.py
+++ b/eve_tools/ESI/metadata.py
@@ -65,10 +65,18 @@ class ESIRequest:
 
     @property
     def real_url(self) -> URL:
+        """Similar to aiohttp's request_info.real_url."""
         # This is very different from aiohttp's request_info.real_url, 
         # which uses URL class in a more informative way.
         # This method is only intended for printing exception message correctly.
+        if self.url is None:
+            return URL()
         return URL(self.url)
+
+    @property
+    def rid(self):
+        """Request id."""
+        return (self.request_key, self.request_type, self.kwd, "request_id")
 
 
 class ESIMetadata(object):

--- a/eve_tools/ESI/parser.py
+++ b/eve_tools/ESI/parser.py
@@ -1,0 +1,271 @@
+import copy
+from ctypes import Union
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from .token import ESITokens
+from .metadata import ESIRequest, ESIMetadata
+from eve_tools.log import getLogger
+from eve_tools.data import SqliteCache, CacheDB
+
+if TYPE_CHECKING:
+    from eve_tools.ESI.application import ESIApplications
+    from eve_tools.data.db import ESIDBManager
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class ETagEntry:
+    """Struct for storing etag and etag's payload."""
+
+    etag: str
+    payload: Optional[Any]
+
+
+class ESIRequestParser:
+    """Parses user input parameters to a formalized ``ESIRequest`` instance."""
+
+    def __init__(self, apps: "ESIApplications", cache: "ESIDBManager" = ...) -> None:
+        self.metadata = ESIMetadata()
+        self.apps = apps
+        self.metaurl = "https://esi.evetech.net/latest"
+
+        if cache is Ellipsis:
+            self.etag_cache = SqliteCache(CacheDB, table="etag_cache")
+        else:
+            self.etag_cache = cache
+
+        self.user_agent = "python-eve_tools/ESIClient"
+
+    async def __call__(self, key: str, method: str, **kwd) -> ESIRequest:
+        """Parses user input ``key``, ``method``, and keywords to a ``ESIRequest``.
+
+        This method first consults with ``ESIMetadata`` to retrieve metadata information of a request endpoint.
+        Then fills users input parameters to ``headers`` and ``params``.
+
+        Args:
+            key: str
+                ESI request key, in "/.../.../" format, retrieved from ESI website.
+            method: str
+                One of ``get``, ``head``. ``post`` and other methods are not supported.
+
+        Returns:
+            An ``ESIRequest`` instance, with all relevent fields filled in.
+        """
+
+        api_request = self.metadata[key]  # metadata of endpoint
+        self.__check_method(api_request, method)
+
+        api_request.kwd = copy.deepcopy(kwd)
+
+        params = kwd.get("params", {})
+        api_request.params.update(params)
+
+        # Update request headers
+        self.__generate_req_headers(api_request, kwd)
+
+        # Parse user input keyword
+        self.__parse_request_keywords(api_request, kwd)
+
+        return api_request
+
+    def __check_method(self, api_request: ESIRequest, method: str) -> None:
+        """Checks if request method is supported by ESI.
+
+        Args:
+            api_request: ESIRequest
+                Request info for a request. Retrieved from ``ESIMetadata.__getitem__``.
+            method: str
+                User input request method.
+        """
+        if api_request.request_type not in ["get", "head"]:
+            raise NotImplementedError(f"Request type {api_request.request_type} is not supported.")
+
+        req_method = api_request.request_type
+        if req_method == method:
+            return
+
+        if method == "head" and req_method == "get":
+            return
+
+        logger.error("Invalid request method: %s for %s", method, api_request.request_key)
+        raise NotImplementedError(
+            f"Request method {method} is not supported by {api_request.request_key} request."
+        )
+
+    def __generate_req_headers(self, api_request: ESIRequest, kwd: dict) -> dict:
+        """Generates request headers from metadata.
+
+        Most ESI request needs no user-input headers, but some request headers are useful,
+        such as ``If-None-Match`` and ``User-Agent``.
+        This method defines default value of these useful HTTP request headers field.
+        """
+        headers: dict = {}
+
+        # Add oauth to headers
+        if api_request.security and "Authorization" not in headers:  # some method does not need oauth
+            app = self.apps.search_scope(" ".join(api_request.security))  # find matching application
+            with ESITokens(app) as tokens:
+                cname = kwd.pop("cname", "any")  # "any" for matching any token
+                token = tokens.generate() if not tokens.exist(cname) else tokens[cname]
+                api_request.token = token
+                access_token = token.access_token
+                headers["Authorization"] = "Bearer {}".format(access_token)
+
+        # Add If-None-Match to headers
+        # Comply with HTTP Etag headers, see https://developers.eveonline.com/blog/article/esi-etag-best-practices.
+        if "If-None-Match" not in headers:
+            headers["If-None-Match"] = self._get_etag(api_request.rid)
+
+        # Add User-Agent to headers
+        # Provides better bookkeeping for ESI servers.
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = self.user_agent
+
+        api_request.headers.update(headers)
+
+    def _get_etag(self, request_id: tuple) -> str:
+        """Gets etag value for a request with ``request_id``.
+
+        If no matching etag, returns empty string."""
+        etag: ETagEntry = self.etag_cache.get(request_id)
+        return etag.etag if etag is not None and etag.etag is not None else ""
+
+    def _get_etag_payload(self, request_id: tuple) -> str:
+        """Gets response content for request with ``request_id``.
+
+        Use this method when ESI returns ``status: 304``."""
+        etag: ETagEntry = self.etag_cache.get(request_id)
+        return etag.payload if etag is not None else None
+
+    def _set_etag(self, request_id: tuple, etag: str, payload: Any) -> None:
+        """Sets cache entry with key: ``request_id``, value: ``ETagEntry(etag, payload)``."""
+        value = ETagEntry(etag, payload)
+        # An expires param is given for safety.
+        # If for example response content has updated, this ``set`` would update etag for a request.
+        # If for example a request is rare, this request's etag would be deleted after 7 days (reasonably long time).
+        self.etag_cache.set(request_id, value, 24 * 3600 * 7)
+
+    def __parse_request_keywords(self, api_request: ESIRequest, keywords: dict) -> None:
+        """Parses user input parameters according to endpoints metadata.
+
+        Checks fields in ``keywords`` if necessary parameters are given.
+        If given, fills in ``api_request`` with fields from keywords.
+        If not, either raises errors if field is ``required``, or fill in default value if defined by ESI metadata.
+
+        Args:
+            api_request: ESIRequest
+                Request info for a request. Retrieved from ``ESIMetadata.__getitem__``.
+                Necessary info (url, params, headers) should be filled in by ``ESIMetadata``.
+            keywords: dict
+                Keywords provided by user, containing ``headers``, ``params``, and other necessary fields defined by ESI,
+                such as ``character_id``, ``type_id``, etc.
+                If ESI metadata marks fields as ``required``, missing these fields in ``keywords`` raises errors.
+
+        Facts:
+            _in: path
+                1. Always marked as ``required``
+                2. Appears as ``Param.name`` in url: https://.../characters/{character_id}/orders/
+                3. Pass in with kwd argument, not params, headers, or data
+                4. No default value defined by ESI
+            _in: query
+                1. Pass in with either ``kwd or ``params``, not ``headers``
+                2. Appears as ``?query=value`` in url: https://.../?datasource=tranquility
+            _in: header
+                1. Request token has been updated to headers before calling this function
+                2. ESI marks ``token`` field as optional
+
+        Note:
+            ``dtype`` field in ESI metadata is not checked nor enforced.
+        """
+
+        path_params = {}  # params for request url.format()
+        query_params = {}  # params for url/?{key1}={value1}?{key2}={value2}...
+        headers = keywords.pop("headers", {})
+
+        cid = 0
+        if api_request.token is not None:
+            # Update to tackle ESI's authenticated search endpoint, see https://github.com/esi/esi-issues/issues/1323.
+            cid = api_request.token.character_id
+
+        for api_param_ in api_request.parameters:
+            # Each param has a "in" field defined by metadata.
+            if api_param_._in == "path":
+                key = api_param_.name
+                value = self.__parse_request_keywords_in_path(keywords, key, api_param_.dtype, cid)
+                path_params.update({key: value})  # dict unpacking later
+
+            elif api_param_._in == "query":
+                default = api_param_.default
+                key = api_param_.name
+                value = self.__parse_request_keywords_in_query(
+                    keywords,
+                    key,
+                    api_param_.required,
+                    api_param_.default,
+                    api_param_.dtype,
+                )
+                if value is not None:
+                    query_params.update({key: value})  # update if value is given
+                elif default is not None:
+                    query_params.update({key: default})  # else update if default is set
+
+            elif api_param_._in == "header":  # not "headers"
+                key = api_param_.name
+                value = self.__parse_request_keywords_in_header(
+                    headers, key, api_param_.required, api_param_.dtype
+                )
+                if value is not None:
+                    headers.update({key: value})
+
+        url = api_request.request_key
+        url = url.format(**path_params)
+        api_request.params.update(query_params)
+        api_request.headers.update(headers)
+        api_request.url = self.metaurl + url  # urljoin is difficult to deal with...
+
+    @staticmethod
+    def __parse_request_keywords_in_path(where: dict, key: str, dtype: str, cid: int = 0) -> str:
+        # dtype is not checked yet. Checking it needs to parse "schema" field and integerate into "dtype",
+        # and needs to find a way to fit user input to the dtype field.
+        # No need to check Param.required because Param._in == "path" => Param.required == True
+        if key == "character_id" and cid > 0 and "character_id" not in where:
+            # Prioritizes user input character_id
+            return cid
+        value = where.pop(key, None)
+        if value is None:
+            raise KeyError(f'Missing key "{key}" in keywords.')
+        return value
+
+    @staticmethod
+    def __parse_request_keywords_in_query(
+        where: dict, key: str, required: bool, default, dtype: str
+    ) -> str:
+        value = where.pop(key, None)
+        params = where.get("params")
+        value2 = None
+        if params:
+            value2 = params.get(key)
+
+        if value and value2:
+            raise KeyError(f'Duplicate key "{key}" in both keywords and params.')
+
+        if value is None and value2 is None and required and default is None:
+            raise KeyError(f'Missing key "{key}" in keywords.')
+
+        if value is None and value2 is None:
+            return default
+        if value is not None:
+            return value
+        if value2 is not None:
+            return value2
+
+    @staticmethod
+    def __parse_request_keywords_in_header(where: dict, key: str, required: bool, dtype: str) -> str:
+        value = where.pop(key, None)
+        if not required:
+            return value
+        if value is None:
+            raise KeyError(f'Missing key "{key}" in keywords.')
+        return value

--- a/eve_tools/data/schema.yml
+++ b/eve_tools/data/schema.yml
@@ -33,7 +33,7 @@ esi:
       PRIMARY KEY(type_id, region_id, date)
 
 cache:
-  tables: [api_cache, checker_cache]
+  tables: [api_cache, checker_cache, etag_cache]
   api_cache:
     schema:
       key TEXT PRIMARY KEY,
@@ -41,6 +41,13 @@ cache:
       expires TIMESTAMP NOT NULL
   checker_cache:
     schema:
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      expires TIMESTAMP NOT NULL
+  etag_cache:
+    schema:
+      # key: request id (rid)
+      # value: ETagEntry (etag, payload)
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL,
       expires TIMESTAMP NOT NULL

--- a/eve_tools/tests/__init__.py
+++ b/eve_tools/tests/__init__.py
@@ -1,5 +1,5 @@
 from .test_tests import TestUtils
 from .test_data import TestCache
+from .test_esi import TestSSO, TestMetadata, TestParser, TestRequestChecker, TestESI
 from .test_api import TestMarket, TestSearch
-from .test_esi import TestESI, TestRequestChecker, TestSSO
 from .utils import test_config

--- a/eve_tools/tests/test_esi.py
+++ b/eve_tools/tests/test_esi.py
@@ -1,10 +1,14 @@
 import unittest
 from datetime import datetime
+from yarl import URL
 
 from eve_tools.ESI import ESIClient, ESIRequestChecker
+from eve_tools.ESI.metadata import ESIRequest
+from eve_tools.ESI.parser import ESIRequestParser, ETagEntry
 from eve_tools.ESI.utils import _SessionRecord, ESIRequestError
 from eve_tools.ESI.esi import ESIResponse
 from eve_tools.ESI.sso.utils import to_clipboard, read_clipboard
+from eve_tools.data.utils import hash_key
 from eve_tools.exceptions import InvalidRequestError, ESIResponseError
 from eve_tools.data import CacheDB, SqliteCache
 from eve_tools.tests.utils import request_from_ESI
@@ -114,7 +118,7 @@ class TestESI(unittest.TestCase):
         # Make a correct request first
         resp = ESIClient.get("/markets/{region_id}/history/", region_id=10000002, type_id=12005)
         self.assertIsInstance(resp, ESIResponse)
-        self.assertEqual(resp.status, 200)
+        self.assertTrue(resp.ok)
 
         resp = ESIClient.head("/markets/{region_id}/history/", region_id=10000002, type_id=12005)
         self.assertIsInstance(resp, ESIResponse)
@@ -321,6 +325,54 @@ class TestRequestChecker(unittest.TestCase, TestInit):
         self.TESTDB.clear_db()
         self.checker_cache.buffer.clear()
 
+
+class TestParser(unittest.TestCase, TestInit):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.etag_cache = SqliteCache(cls.TESTDB, "etag_cache")
+        cls.parser = ESIRequestParser(ESIClient.apps, cls.etag_cache)
+
+    def test_etag(self):
+        req = ESIRequest("test key", "get", kwd={"cid": 123, "sid": 234})
+        etag = "test_etag-123456"
+        payload = 12005
+
+        # Test: set_etag
+        self.parser._set_etag(req.rid, etag, payload)
+
+        entry: ETagEntry = self.etag_cache.get(req.rid)
+        self.assertIsNotNone(entry)
+        self.assertIsInstance(entry, ETagEntry)
+        self.assertEqual(entry.etag, etag)
+        self.assertEqual(entry.payload, payload)
+
+        # Test: get_etag
+        self.assertEqual(self.parser._get_etag(req.rid), etag)
+
+        ret = self.parser._get_etag("some nonexisting rid")
+        self.assertEqual(ret, "")  # "ETag" : "" is allowed in http
+
+        # Test: get_etag_payload
+        self.assertEqual(self.parser._get_etag_payload(req.rid), payload)
+
+        ret = self.parser._get_etag_payload("some nonexisting rid")
+        self.assertIsNone(ret)  # payload should be None if non-existing
+
+    def tearDown(self) -> None:
+        self.TESTDB.clear_table("etag_cache")
+        self.etag_cache.buffer.clear()
+
+
+class TestMetadata(unittest.TestCase):
+
+    def test_request_info(self):
+        """Test ESIRequest()."""
+        req = ESIRequest("test key", "get", kwd={"cid": 123, "sid": 234})
+        req2 = ESIRequest("test key", "get", kwd={"sid": 234, "cid": 123})
+        self.assertEqual(req.rid, req2.rid)
+
+        url = req.real_url
+        self.assertEqual(url, URL())  # empty url
 
 class TestSSO(unittest.TestCase):
     def test_pc_copy(self):


### PR DESCRIPTION
Adds support for ``If-None-Match`` and ``Etag headers``, which could reduce exchange local storage for lower internet traffic. The parsing methods are seperated from ``ESI``, with a new class called ``ESIRequestParser``.
* Add ESIRequestParser
* Support If-None-Match headers
* Support response with status 304
* Add etag_cache table to cache database

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added and passed (if fixing a bug or adding a new feature)
- [x] Entry in the latest doc/source/whatsnew/vX.X.X.rst file (if fixing a bug or adding a new feature)